### PR TITLE
fix constant name 35-calling-functions/270-deterministic

### DIFF
--- a/modules/35-calling-functions/270-deterministic/index.py
+++ b/modules/35-calling-functions/270-deterministic/index.py
@@ -1,7 +1,7 @@
 from hexlet.code_basics import to_upper_case
 
-text = 'knock!'
+TEXT = 'knock!'
 
 # BEGIN
-print(to_upper_case(text))
+print(to_upper_case(TEXT))
 # END


### PR DESCRIPTION
Поправил имя константы, записал её большими буквами. В задании указано, что  text это константа