### PR TITLE
Fix the test expected value

### DIFF
--- a/modules/38-objects/500-method-chain/test_code.py
+++ b/modules/38-objects/500-method-chain/test_code.py
@@ -2,5 +2,5 @@ from hexlet.test import expect_output
 
 
 def test(capsys):
-    expected = '7'
+    expected = '8'
     expect_output(capsys, expected)


### PR DESCRIPTION
Here is detailed execution:

>>> text = 'When \t\n you play a \t\n game of thrones you win or you die.'
>>> a = text[5:16]
>>> a
'\t\n you play'
>>> b = a.strip()
>>> b
'you play'
>>> len(b)
8