### PR TITLE
Исправлено избыточное использование f-строк

### DIFF
--- a/modules/40-define-functions/500-named-arguments/index.py
+++ b/modules/40-define-functions/500-named-arguments/index.py
@@ -1,2 +1,2 @@
 def trim_and_repeat(text, offset=0, repetitions=1):
-    return f'{text[offset:] * repetitions}'
+    return text[offset:] * repetitions


### PR DESCRIPTION
В данной задаче использование f-строк излишне, так как str * int возвращает тип str.