### PR TITLE
style: fix PEP 8 violations in exercise test files

### DIFF
--- a/modules/40-define-functions/150-return/test_solution.py
+++ b/modules/40-define-functions/150-return/test_solution.py
@@ -1,5 +1,6 @@
 import solution
 
+
 def test():
     assert solution.truncate("hexlet", 2) == "he..."
     assert solution.truncate("it works!", 4) == "it w..."

--- a/modules/40-define-functions/250-named-arguments/test_solution.py
+++ b/modules/40-define-functions/250-named-arguments/test_solution.py
@@ -5,4 +5,6 @@ def test():
     assert solution.trim_and_repeat("python") == "python"
     assert solution.trim_and_repeat("python", offset=4) == "on"
     assert solution.trim_and_repeat("python", repetitions=2) == "pythonpython"
-    assert solution.trim_and_repeat("python", offset=4, repetitions=2) == "onon"
+    assert (
+        solution.trim_and_repeat("python", offset=4, repetitions=2) == "onon"
+    )

--- a/modules/45-logic/15-bool-strings/test_solution.py
+++ b/modules/45-logic/15-bool-strings/test_solution.py
@@ -1,5 +1,6 @@
 import solution
 
+
 def test1():
     assert not solution.is_long_word("apple")  # 5 символов → False
     assert solution.is_long_word("banana")  # 6 символов → True

--- a/modules/48-conditionals/40-if-else/test_solution.py
+++ b/modules/48-conditionals/40-if-else/test_solution.py
@@ -5,13 +5,20 @@ def test():
     assert solution.normalize_url("yandex.ru") == "https://yandex.ru"
     assert solution.normalize_url("http://yandex.ru") == "https://yandex.ru"
     assert solution.normalize_url("https://yandex.ru") == "https://yandex.ru"
-    assert solution.normalize_url("httpsecurity.com") == "https://httpsecurity.com"
     assert (
-        solution.normalize_url("https://httpbin.org/redirect-to?url=http://google.com")
+        solution.normalize_url("httpsecurity.com")
+        == "https://httpsecurity.com"
+    )
+    assert (
+        solution.normalize_url(
+            "https://httpbin.org/redirect-to?url=http://google.com"
+        )
         == "https://httpbin.org/redirect-to?url=http://google.com"
     )
     assert (
-        solution.normalize_url("httpbin.org/redirect-to?url=https://google.com")
+        solution.normalize_url(
+            "httpbin.org/redirect-to?url=https://google.com"
+        )
         == "https://httpbin.org/redirect-to?url=https://google.com"
     )
     assert (

--- a/modules/50-loops/23-aggregation-strings/test_solution.py
+++ b/modules/50-loops/23-aggregation-strings/test_solution.py
@@ -2,6 +2,8 @@ import solution
 
 
 def test1():
-    assert solution.sanitize_phone_number("+7 (999) 123-45-67") == "+79991234567"
+    assert (
+        solution.sanitize_phone_number("+7 (999) 123-45-67") == "+79991234567"
+    )
     assert solution.sanitize_phone_number("8 800 555 35 35") == "88005553535"
     assert solution.sanitize_phone_number("(123) 456-7890") == "1234567890"

--- a/modules/50-loops/80-for-in-range/test_solution.py
+++ b/modules/50-loops/80-for-in-range/test_solution.py
@@ -5,4 +5,6 @@ def test():
     assert fizzbuzz(1) == "1"
     assert fizzbuzz(3) == "1 2 Fizz"
     assert fizzbuzz(5) == "1 2 Fizz 4 Buzz"
-    assert fizzbuzz(15) == "1 2 Fizz 4 Buzz Fizz 7 8 Fizz Buzz 11 Fizz 13 14 FizzBuzz"
+    assert fizzbuzz(15) == (
+        "1 2 Fizz 4 Buzz Fizz 7 8 Fizz Buzz 11 Fizz 13 14 FizzBuzz"
+    )


### PR DESCRIPTION
style: fix PEP 8 violations in exercise test files

Устранены предупреждения pycodestyle по умолчанию (лимит 79 символов в строке) в шести тестовых файлах упражнений. Логика тестов, проверки и ожидаемые значения не изменялись — затронуты только пробелы и переносы строк.

Изменения:

- modules/40-define-functions/150-return/test_solution.py Добавлена вторая пустая строка между import и определением def test() (E302: expected 2 blank lines, found 1).

- modules/45-logic/15-bool-strings/test_solution.py Добавлена вторая пустая строка между import и определением def test1() (E302: expected 2 blank lines, found 1).

- modules/48-conditionals/40-if-else/test_solution.py Три длинных assert обёрнуты в круглые скобки, чтобы строки с URL-литералами укладывались в 79 символов (E501: line too long, 83, 87 и 80 символов). Это согласуется со стилем уже присутствующих ниже многострочных assert.

- modules/50-loops/80-for-in-range/test_solution.py Длинный assert с fizzbuzz(15) обёрнут в круглые скобки, чтобы уложиться в 79 символов (E501: line too long, 86 символов). Ожидаемая выходная строка не изменена.

- modules/40-define-functions/250-named-arguments/test_solution.py Длинный assert с trim_and_repeat обёрнут в круглые скобки (E501: line too long, 80 символов).

- modules/50-loops/23-aggregation-strings/test_solution.py Длинный assert с sanitize_phone_number обёрнут в круглые скобки (E501: line too long, 81 символ).

Closes #360