### PR TITLE
fix: показывать вывод программы студента на панели «вывод»

### DIFF
--- a/modules/10-basics/10-hello-world/test_solution.py
+++ b/modules/10-basics/10-hello-world/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "Hello, World!"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/10-basics/30-instructions/test_solution.py
+++ b/modules/10-basics/30-instructions/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "Заказ №1337\nСтатус: доставляется\nПримерный срок: 2 дня"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/10-basics/40-testing/test_solution.py
+++ b/modules/10-basics/40-testing/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "10"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/10-basics/50-syntax-errors/test_solution.py
+++ b/modules/10-basics/50-syntax-errors/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "Программа успешно запущена"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/20-arithmetics/20-basic/test_solution.py
+++ b/modules/20-arithmetics/20-basic/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "9.0"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/20-arithmetics/25-operator/test_solution.py
+++ b/modules/20-arithmetics/25-operator/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "87\n29.0"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/20-arithmetics/27-commutativity/test_solution.py
+++ b/modules/20-arithmetics/27-commutativity/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "256\n3.0"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/20-arithmetics/30-composition/test_solution.py
+++ b/modules/20-arithmetics/30-composition/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "660"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/20-arithmetics/40-priority/test_solution.py
+++ b/modules/20-arithmetics/40-priority/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "160.0"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/20-arithmetics/43-float/test_solution.py
+++ b/modules/20-arithmetics/43-float/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "0.30000000000000004"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/20-arithmetics/45-linting/test_solution.py
+++ b/modules/20-arithmetics/45-linting/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "4"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/25-strings/10-quotes/test_solution.py
+++ b/modules/25-strings/10-quotes/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = 'The file "user\'s_config.json" was not found.'
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/25-strings/15-escape-characters/test_solution.py
+++ b/modules/25-strings/15-escape-characters/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = 'Для разделения строк используйте "\\n"\nПример: print("строка1\\nстрока2")'
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/25-strings/20-string-concatenation/test_solution.py
+++ b/modules/25-strings/20-string-concatenation/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "https://github.com/hexlet/exercises-python"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/25-strings/30-encoding/test_solution.py
+++ b/modules/25-strings/30-encoding/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "~\n^\n%"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/30-variables/10-definition/test_solution.py
+++ b/modules/30-variables/10-definition/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "https://hexlet.io\nhttps://hexlet.io"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/30-variables/12-change/test_solution.py
+++ b/modules/30-variables/12-change/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "доставлен"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/30-variables/13-variables-naming/test_solution.py
+++ b/modules/30-variables/13-variables-naming/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "2"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/30-variables/15-variables-expressions/test_solution.py
+++ b/modules/30-variables/15-variables-expressions/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "125.0\n863.75"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/30-variables/18-variable-concatenation/test_solution.py
+++ b/modules/30-variables/18-variable-concatenation/test_solution.py
@@ -1,10 +1,20 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = """Здравствуйте, Анна!
 Спасибо за ваш заказ.
 Ожидаемая дата доставки — 3 рабочих дня."""
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/30-variables/19-naming-style/test_solution.py
+++ b/modules/30-variables/19-naming-style/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "2000"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/30-variables/20-magic-numbers/test_solution.py
+++ b/modules/30-variables/20-magic-numbers/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "Ящиков на складе:\n102"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/31-advanced-strings/25-interpolation/test_solution.py
+++ b/modules/31-advanced-strings/25-interpolation/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "Здравствуйте, Анна! Ваш заказ #1337 принят."
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/31-advanced-strings/30-symbols/test_solution.py
+++ b/modules/31-advanced-strings/30-symbols/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "grip"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/31-advanced-strings/70-slices/test_solution.py
+++ b/modules/31-advanced-strings/70-slices/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "hexlet.io"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/31-advanced-strings/90-multiline-strings/test_solution.py
+++ b/modules/31-advanced-strings/90-multiline-strings/test_solution.py
@@ -1,4 +1,4 @@
-import runpy
+import importlib
 
 
 def test(capsys):
@@ -6,6 +6,16 @@ def test(capsys):
 Ваш заказ успешно оформлен.
 Ожидаемая дата доставки: 3-5 рабочих дней.
 Спасибо, что выбрали нас!"""
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/33-data-types/40-primitive-data-types/test_solution.py
+++ b/modules/33-data-types/40-primitive-data-types/test_solution.py
@@ -1,4 +1,4 @@
-import runpy
+import importlib
 
 
 def test(capsys):
@@ -6,6 +6,16 @@ def test(capsys):
 Birth year: 1994
 Age: 32
 Rating: 4.7"""
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/33-data-types/45-tuples/test_solution.py
+++ b/modules/33-data-types/45-tuples/test_solution.py
@@ -1,11 +1,20 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = """From: Moscow
 To: Saint Petersburg
 Distance: 634 km"""
+    expect_output(capsys, expected)
 
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/33-data-types/50-strong-typing/test_solution.py
+++ b/modules/33-data-types/50-strong-typing/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "13"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/33-data-types/52-data-types-immutability/test_solution.py
+++ b/modules/33-data-types/52-data-types-immutability/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "print"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/33-data-types/55-data-types-casting/test_solution.py
+++ b/modules/33-data-types/55-data-types-casting/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "36 °C"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/35-calling-functions/100-call/test_solution.py
+++ b/modules/35-calling-functions/100-call/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "12"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/35-calling-functions/135-calling-functions-default-params/test_solution.py
+++ b/modules/35-calling-functions/135-calling-functions-default-params/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "37.8\n2426.76\n607"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/35-calling-functions/150-calling-functions-expression/test_solution.py
+++ b/modules/35-calling-functions/150-calling-functions-expression/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "First: H\nLast: !"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/35-calling-functions/180-variadic-parameters/test_solution.py
+++ b/modules/35-calling-functions/180-variadic-parameters/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "-3"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/35-calling-functions/270-deterministic/test_solution.py
+++ b/modules/35-calling-functions/270-deterministic/test_solution.py
@@ -1,4 +1,4 @@
-import runpy
+import importlib
 
 
 def check(output):
@@ -9,6 +9,11 @@ def check(output):
 
 
 def test(capsys):
-    runpy.run_module('solution')
+    importlib.import_module('solution')
     out, _ = capsys.readouterr()
-    check(out.strip())
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    check(out.strip('\n'))

--- a/modules/38-objects/100-objects/test_solution.py
+++ b/modules/38-objects/100-objects/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "the quick brown fox jumps over the lazy dog"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/38-objects/200-methods-immutability/test_solution.py
+++ b/modules/38-objects/200-methods-immutability/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "Grigor"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/38-objects/500-method-chain/test_solution.py
+++ b/modules/38-objects/500-method-chain/test_solution.py
@@ -1,8 +1,18 @@
-import runpy
+import importlib
 
 
 def test(capsys):
     expected = "7"
-    runpy.run_module('solution')
-    out, _ = capsys.readouterr()
-    assert out.strip() == expected
+    expect_output(capsys, expected)
+
+
+def expect_output(capsys, expected):
+    importlib.import_module('solution')
+    out, _err = capsys.readouterr()
+    actual = out.strip('\n')
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert actual == expected

--- a/modules/40-define-functions/100-define-function/test_solution.py
+++ b/modules/40-define-functions/100-define-function/test_solution.py
@@ -2,7 +2,12 @@ import solution
 
 
 def test(capsys):
-    solution.say_hello()
     expected = "Hello, World!"
+    solution.say_hello()
     out, _ = capsys.readouterr()
-    assert out.strip() == expected
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert out.strip('\n') == expected

--- a/modules/50-loops/10-while/test_solution.py
+++ b/modules/50-loops/10-while/test_solution.py
@@ -4,10 +4,20 @@ import solution
 def test1(capsys):
     solution.print_countdown(2)
     out, _ = capsys.readouterr()
-    assert out.strip() == "2\n1\nGo!"
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert out.strip('\n') == "2\n1\nGo!"
 
 
 def test2(capsys):
     solution.print_countdown(4)
     out, _ = capsys.readouterr()
-    assert out.strip() == "4\n3\n2\n1\nGo!"
+
+    with capsys.disabled():
+        print('\n')
+        print(out)
+
+    assert out.strip('\n') == "4\n3\n2\n1\nGo!"


### PR DESCRIPTION
## Проблема

На панели **«вывод»** в уроках Python при успешном решении показывалась только точка `.`, а не результат работы кода студента (задание при этом засчитывалось).

Причина — сочетание двух факторов:

- панель «вывод» отображает **дословный stdout** команды `make test` урока;
- тесты «выводных» уроков перехватывали `print()` студента фикстурой `capsys`, а `readouterr()` **поглощал** этот вывод, нигде не перепечатывая. В связке с `pytest ... -q` (точка за пройденный тест) на панели оставалась только `.`.

## Решение

После `readouterr()` вывод переиздаётся через `with capsys.disabled(): print(out)` — под `--capture=no` он идёт в реальный stdout и попадает на панель. `assert` выполняется **после** печати, поэтому вывод виден и при провале теста. Хелпер `expect_output` встроен прямо в файл теста — урок остаётся самодостаточным, без внешнего пакета.

## Область изменений

Затронут **41 файл** `test_solution.py` (уроки, где решение печатает вывод):

- **38 уроков** с выводом на верхнем уровне (`runpy.run_module` → `importlib.import_module`) — единый шаблон `expect_output`;
- **3 особых**: `35-calling-functions/270-deterministic` (валидатор диапазона) и два, где тест вызывает функцию (`40-define-functions/100-define-function`, `50-loops/10-while`) — там сохранён вызов функции + добавлено переиздание.

Не менялись: `bin/test.sh`, `pyproject.toml`, `Dockerfile`, функциональные уроки без `print` (выводить нечего), `10-basics/20-comments` (вывод уже работал).

## Проверка

- вывод виден на всех типах уроков (`Hello, World!`, многострочные тексты, countdown, значение валидатора);
- `make compose-test` — вся сюита зелёная;
- `make compose-code-lint` (ruff) — `All checks passed!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)